### PR TITLE
Feature/rename and fix uc witnessprotection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,7 +293,7 @@ services:
       MOTOR_STATES_4: error
 
   phpmyadmin:
-    image: phpmyadmin/phpmyadmin:5.2.3
+    image: docker.io/phpmyadmin:5.2.3-apache
     container_name: pma
     networks:
       - kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     container_name: controller
     networks:
       - kafka
-    ports:
-      - "29092:29092"
     environment:
       KAFKA_PROCESS_ROLES: "controller"
       KAFKA_NODE_ID: 1
@@ -28,6 +26,7 @@ services:
       - "9092:9092"
       - "9093:9093"
       - "9094:9094"
+      - "29092:29092"
     depends_on:
       - controller
     volumes:

--- a/uc-witness-protection/connectors/Exercise0jdbc-connector.json
+++ b/uc-witness-protection/connectors/Exercise0jdbc-connector.json
@@ -9,7 +9,7 @@
     "value.converter": "org.apache.kafka.connect.storage.StringConverter",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "mode":"bulk",
-    "table.blacklist":"none",
+    "table.whitelist":"events",
     "poll.interval.ms" : 3600
   }
 }

--- a/uc-witness-protection/kafka-stream/pom.xml
+++ b/uc-witness-protection/kafka-stream/pom.xml
@@ -9,10 +9,10 @@
 		<relativePath/>
 	</parent>
 	<groupId>com.zuehlke.training.kafka.witnessprotection</groupId>
-	<artifactId>kafka-stream</artifactId>
+	<artifactId>witness-protection</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>kafka-stream</name>
-	<description>kafka-stream</description>
+	<name>witness-protection</name>
+	<description>witness-protection</description>
 	<properties>
 		<java.version>23</java.version>
 	</properties>

--- a/uc-witness-protection/kafka-stream/src/main/java/com/zuehlke/training/kafka/witnessprotection/config/KafkaStreamsConfig.java
+++ b/uc-witness-protection/kafka-stream/src/main/java/com/zuehlke/training/kafka/witnessprotection/config/KafkaStreamsConfig.java
@@ -1,0 +1,32 @@
+package com.zuehlke.training.kafka.witnessprotection.config;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.KafkaStreamsConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaStreamsConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.streams.application-id}")
+    private String applicationId;
+
+    @Bean(name = "defaultKafkaStreamsConfig")
+    public KafkaStreamsConfiguration kStreamsConfig() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+
+        return new KafkaStreamsConfiguration(props);
+    }
+}

--- a/uc-witness-protection/kafka-stream/src/main/resources/application.yml
+++ b/uc-witness-protection/kafka-stream/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   kafka:
-    bootstrap-servers: myVMsIP:9094,localhost:9092
+    bootstrap-servers: myVMsIP:9094,localhost:29092
     streams:
       application-id: witnessprotection-kafka-stream
       properties:


### PR DESCRIPTION
# Fixes the following

## Problems with phpmyadmin image

the following error occurred with the image `phpmyadmin/phpmyadmin:5.2.3`

```bash
apache2: symbol lookup error: /usr/local/lib/php/extensions/no-debug-non-zts-20230831/sodium.so: undefined symbol: crypto_secretbox_open_easy
::1 - - [26/Feb/2026:14:55:34 +0000] "OPTIONS \* HTTP/1.0" 200 126 "-" "Apache/2.4.65 (Debian) PHP/8.3.26 (internal dummy connection)"
apache2: symbol lookup error: /usr/local/lib/php/extensions/no-debug-non-zts-20230831/sodium.so: undefined symbol: randombytes_close
```

- fixed by using `docker.io/phpmyadmin:5.2.3-apache`

## Problems with startup

- fixed by adding [KafkaStreamsConfig.java](uc-witness-protection/kafka-stream/src/main/java/com/zuehlke/training/kafka/witnessprotection/config/KafkaStreamsConfig.java)

## Error `java.net.UnknownHostException: broker`

- fixed by changing bootstrap-server to `localhost:29092`

## Further fixes

- rename the application